### PR TITLE
Zoooooooom

### DIFF
--- a/Example/Controllers/ViewController.swift
+++ b/Example/Controllers/ViewController.swift
@@ -109,10 +109,8 @@ class ViewController: UIViewController {
     }
 
     private func resetStartButton() {
-        DispatchQueue.main.async {
-            self.startButton.setTitle("Start", for: [])
-            self.startButton.isSelected = false
-        }
+        self.startButton.setTitle("Start", for: [])
+        self.startButton.isSelected = false
     }
 
     @objc func toggleLivestream() {
@@ -133,12 +131,16 @@ class ViewController: UIViewController {
             }
 
             liveStream?.onConnectionFailed = { code in
-                self.callAlert(code: code)
-                self.resetStartButton()
+                DispatchQueue.main.async {
+                    self.callAlert(code: code)
+                    self.resetStartButton()
+                }
             }
             liveStream?.onDisconnect = { () in
-                self.callAlert(code: "Disconnect")
-                self.resetStartButton()
+                DispatchQueue.main.async {
+                    self.callAlert(code: "Disconnect")
+                    self.resetStartButton()
+                }
             }
             startButton.setTitle("Stop", for: [])
         }

--- a/Example/Controllers/ViewController.swift
+++ b/Example/Controllers/ViewController.swift
@@ -16,6 +16,10 @@ class ViewController: UIViewController {
     private let mute = UIImage(systemName: "speaker.slash.circle")
     private let unMute = UIImage(systemName: "speaker.circle")
     private let parameter = UIImage(systemName: "ellipsis")
+    
+    private lazy var zoomGesture: UIPinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(zoom(sender:)))
+    private var currentZoomFactor: CGFloat = 1.0
+    public var pinchZoomMultiplier: CGFloat = 2.2
 
     private var nc = NotificationCenter.default
 
@@ -76,6 +80,8 @@ class ViewController: UIViewController {
         muteButton.addTarget(self, action: #selector(toggleMute), for: .touchUpInside)
         startButton.addTarget(self, action: #selector(toggleLivestream), for: .touchUpInside)
         parameterButton.addTarget(self, action: #selector(navigateToParam), for: .touchUpInside)
+        
+        preview.addGestureRecognizer(zoomGesture)
 
         constraints()
     }
@@ -185,6 +191,16 @@ class ViewController: UIViewController {
                     self.updateConfig()
                 }
             }
+        }
+    }
+    
+    @objc
+    private func zoom(sender: UIPinchGestureRecognizer) {
+        if sender.state == .changed {
+            //currentZoomFactor = min(4, max(1, currentZoomFactor + (sender.scale-1) * pinchZoomMultiplier))
+            //rtmpStream.setZoomFactor(currentZoomFactor)
+            liveStream?.zoomRatio = (liveStream?.zoomRatio ?? 1.0) + (sender.scale-1) * pinchZoomMultiplier
+            sender.scale = 1
         }
     }
 }

--- a/Example/Controllers/ViewController.swift
+++ b/Example/Controllers/ViewController.swift
@@ -16,10 +16,9 @@ class ViewController: UIViewController {
     private let mute = UIImage(systemName: "speaker.slash.circle")
     private let unMute = UIImage(systemName: "speaker.circle")
     private let parameter = UIImage(systemName: "ellipsis")
-    
-    private lazy var zoomGesture: UIPinchGestureRecognizer = UIPinchGestureRecognizer(target: self, action: #selector(zoom(sender:)))
-    private var currentZoomFactor: CGFloat = 1.0
-    public var pinchZoomMultiplier: CGFloat = 2.2
+
+    private lazy var zoomGesture: UIPinchGestureRecognizer = .init(target: self, action: #selector(zoom(sender:)))
+    private let pinchZoomMultiplier: CGFloat = 2.2
 
     private var nc = NotificationCenter.default
 
@@ -80,7 +79,7 @@ class ViewController: UIViewController {
         muteButton.addTarget(self, action: #selector(toggleMute), for: .touchUpInside)
         startButton.addTarget(self, action: #selector(toggleLivestream), for: .touchUpInside)
         parameterButton.addTarget(self, action: #selector(navigateToParam), for: .touchUpInside)
-        
+
         preview.addGestureRecognizer(zoomGesture)
 
         constraints()
@@ -115,8 +114,8 @@ class ViewController: UIViewController {
     }
 
     private func resetStartButton() {
-        self.startButton.setTitle("Start", for: [])
-        self.startButton.isSelected = false
+        startButton.setTitle("Start", for: [])
+        startButton.isSelected = false
     }
 
     @objc func toggleLivestream() {
@@ -193,13 +192,13 @@ class ViewController: UIViewController {
             }
         }
     }
-    
+
     @objc
     private func zoom(sender: UIPinchGestureRecognizer) {
         if sender.state == .changed {
-            //currentZoomFactor = min(4, max(1, currentZoomFactor + (sender.scale-1) * pinchZoomMultiplier))
-            //rtmpStream.setZoomFactor(currentZoomFactor)
-            liveStream?.zoomRatio = (liveStream?.zoomRatio ?? 1.0) + (sender.scale-1) * pinchZoomMultiplier
+            if let liveStream = liveStream {
+                liveStream.zoomRatio = liveStream.zoomRatio + (sender.scale - 1) * pinchZoomMultiplier
+            }
             sender.scale = 1
         }
     }

--- a/Sources/ApiVideoLiveStream.swift
+++ b/Sources/ApiVideoLiveStream.swift
@@ -67,7 +67,7 @@ public class ApiVideoLiveStream {
             rtmpStream.audioSettings[.muted] = newValue
         }
     }
-    
+
     public var zoomRatio: CGFloat {
         get {
             return rtmpStream.zoomFactor
@@ -210,7 +210,6 @@ public class ApiVideoLiveStream {
     /// Stop your livestream
     /// - Returns: Void
     public func stopStreaming() {
-
         let isConnected = rtmpConnection.connected
         rtmpConnection.close()
         rtmpConnection.removeEventListener(.rtmpStatus, selector: #selector(rtmpStatusHandler), observer: self)


### PR DESCRIPTION
## Issue
Generally missing a zoom functionality.
Mentioned in:
https://github.com/apivideo/api.video-reactnative-live-stream/issues/9

## Description of the Change
Added property "zoomEnabled" that defines if the pinch gesture handler should be active. The actual zoom function is called "Zoom" which uses the property currentZoomFactor to keep a persistant zoom factor across multiple gesture frames.

At the moment the zoom functionality will not work until a stream has been started. - This will have to be fixed before being merged. But need to know how this should be handled as to not break any other libraries depending on this one.

## Alternate Designs
It would be possible to have a gesture handler directly from React Native or Flutter which just passes down a zoom factor which will be passed into `rtmpStream.setZoomFactor`. But in my experience is not ideal. You have two different systems that output the pinch gesture data slightly different. One method would give you two different outcomes.

## Possible Drawbacks
Some people might get confused. With React Native, if you draw a View with Position: "Absolute" over the preview. That View would capture all of the click events. So you will need to add `pointerEvents="none"` to the view stretching over the preview to make touches go through that view.

## Verification Process
Tested in development mode with both the native example given by this library. And also tested with example given with the api.video-reactnative-live-stream library.

Asserted that the zoom did not function until the stream were started.