### PR TITLE
Update to Hashinkit 1.5.2

### DIFF
--- a/Examples/ExampleUIKit/ExampleUIKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/ExampleUIKit/ExampleUIKit.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shogo4405/HaishinKit.swift",
       "state" : {
-        "revision" : "ec24c44b9422a4391ce1c08bc9cd76364936fc73",
-        "version" : "1.4.2"
+        "revision" : "1d851afe324242ade5b513f98b124484817cf603",
+        "version" : "1.5.2"
       }
     },
     {
@@ -23,8 +23,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shogo4405/Logboard.git",
       "state" : {
-        "revision" : "0213f0b41c37d2e958b261657b72ce3801f472f9",
-        "version" : "2.3.0"
+        "revision" : "e597fa65bb2ce9fc56935b4161b1af74495ddb52",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shogo4405/HaishinKit.swift",
       "state" : {
-        "revision" : "67db4b55fda970453fa58906fb37159ea7ff4a7c",
-        "version" : "1.4.3"
+        "revision" : "1d851afe324242ade5b513f98b124484817cf603",
+        "version" : "1.5.2"
       }
     },
     {
@@ -14,8 +14,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/shogo4405/Logboard.git",
       "state" : {
-        "revision" : "0213f0b41c37d2e958b261657b72ce3801f472f9",
-        "version" : "2.3.0"
+        "revision" : "e597fa65bb2ce9fc56935b4161b1af74495ddb52",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/shogo4405/HaishinKit.swift", from: "1.4.3")
+        .package(url: "https://github.com/shogo4405/HaishinKit.swift", from: "1.5.2")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/ApiVideoLiveStream/ApiVideoLiveStream.swift
+++ b/Sources/ApiVideoLiveStream/ApiVideoLiveStream.swift
@@ -27,7 +27,7 @@ public class ApiVideoLiveStream {
     ///  Getter and Setter for an AudioConfig
     public var audioConfig: AudioConfig {
         get {
-            AudioConfig(bitrate: self.rtmpStream.audioSettings[.bitrate] as! Int)
+            AudioConfig(bitrate: self.rtmpStream.audioSettings.bitRate)
         }
         set {
             self.prepareAudio(audioConfig: newValue)
@@ -39,13 +39,13 @@ public class ApiVideoLiveStream {
     public var videoConfig: VideoConfig {
         get {
             try! VideoConfig(
-                bitrate: Int(self.rtmpStream.videoSettings[.bitrate] as! UInt32),
+                bitrate: Int(self.rtmpStream.videoSettings.bitRate),
                 resolution: Resolution.getResolution(
-                    width: Int(self.rtmpStream.videoSettings[.width] as! Int32),
-                    height: Int(self.rtmpStream.videoSettings[.height] as! Int32)
+                    width: Int(self.rtmpStream.videoSettings.videoSize.width),
+                    height: Int(self.rtmpStream.videoSettings.videoSize.height)
                 ),
                 fps: self.rtmpStream.frameRate,
-                gopDuration: self.rtmpStream.videoSettings[.maxKeyFrameIntervalDuration] as! TimeInterval
+                gopDuration: TimeInterval(self.rtmpStream.videoSettings.maxKeyFrameIntervalDuration)
             )
         }
         set {
@@ -55,12 +55,12 @@ public class ApiVideoLiveStream {
 
     // swiftlint:disable force_cast
     /// Getter and Setter for the Bitrate number for the video
-    public var videoBitrate: Int {
+    public var videoBitrate: UInt32 {
         get {
-            self.rtmpStream.videoSettings[.bitrate] as! Int
+            self.rtmpStream.videoSettings.bitRate
         }
         set(newValue) {
-            self.rtmpStream.videoSettings[.bitrate] = newValue
+            self.rtmpStream.videoSettings.bitRate = newValue
         }
     }
 
@@ -151,7 +151,7 @@ public class ApiVideoLiveStream {
         self.rtmpStream = RTMPStream(connection: self.rtmpConnection)
 
         // Force default resolution because HK default resolution is not supported (480x272)
-        self.rtmpStream.videoSettings = [.width: 1_280, .height: 720]
+        self.rtmpStream.videoSettings = VideoCodecSettings(videoSize: .init(width: 1_280, height: 720))
 
         #if os(iOS)
         if let orientation = DeviceUtil.videoOrientation(by: UIApplication.shared.statusBarOrientation) {
@@ -318,16 +318,18 @@ public class ApiVideoLiveStream {
     private func prepareVideo(videoConfig: VideoConfig) {
         self.rtmpStream.frameRate = videoConfig.fps
         self.rtmpStream.sessionPreset = AVCaptureSession.Preset.high
-
-        self.rtmpStream.videoSettings = [
-            .width: self.rtmpStream.videoOrientation.isLandscape ? videoConfig.resolution.size.width : videoConfig
-                .resolution.size.height,
-            .height: self.rtmpStream.videoOrientation.isLandscape ? videoConfig.resolution.size.height : videoConfig
-                .resolution.size.width,
-            .profileLevel: kVTProfileLevel_H264_Baseline_5_2,
-            .bitrate: videoConfig.bitrate,
-            .maxKeyFrameIntervalDuration: videoConfig.gopDuration
-        ]
+        
+        let width = self.rtmpStream.videoOrientation.isLandscape ? videoConfig.resolution.size.width : videoConfig
+            .resolution.size.height
+        let height = self.rtmpStream.videoOrientation.isLandscape ? videoConfig.resolution.size.height : videoConfig
+            .resolution.size.width
+        
+        self.rtmpStream.videoSettings = VideoCodecSettings(
+          videoSize: .init(width: Int32(width), height: Int32(height)),
+          profileLevel: kVTProfileLevel_H264_Baseline_5_2 as String,
+          bitRate: UInt32(videoConfig.bitrate),
+          maxKeyFrameIntervalDuration: Int32(videoConfig.gopDuration)
+        )
 
         self.isVideoConfigured = true
     }
@@ -341,9 +343,9 @@ public class ApiVideoLiveStream {
     }
 
     private func prepareAudio(audioConfig: AudioConfig) {
-        self.rtmpStream.audioSettings = [
-            .bitrate: audioConfig.bitrate
-        ]
+        self.rtmpStream.audioSettings = AudioCodecSettings(
+            bitRate: audioConfig.bitrate
+        )
 
         self.isAudioConfigured = true
     }
@@ -440,15 +442,21 @@ public class ApiVideoLiveStream {
             self.rtmpStream.videoOrientation = orientation
             do {
                 let resolution = try Resolution.getResolution(
-                    width: Int(self.rtmpStream.videoSettings[.width] as! Int32),
-                    height: Int(self.rtmpStream.videoSettings[.height] as! Int32)
+                    width: Int(self.rtmpStream.videoSettings.videoSize.width),
+                    height: Int(self.rtmpStream.videoSettings.videoSize.height)
                 )
-                self.rtmpStream.videoSettings = [
-                    .width: self.rtmpStream.videoOrientation.isLandscape ?
-                        resolution.size.width : resolution.size.height,
-                    .height: self.rtmpStream.videoOrientation.isLandscape ?
-                        resolution.size.height : resolution.size.width
-                ]
+                self.rtmpStream.videoSettings = VideoCodecSettings(
+                    videoSize: .init(
+                        width: Int32(
+                            self.rtmpStream.videoOrientation.isLandscape ?
+                            resolution.size.width : resolution.size.height
+                        ),
+                        height: Int32(
+                            self.rtmpStream.videoOrientation.isLandscape ?
+                            resolution.size.height : resolution.size.width
+                        )
+                    )
+                )
             } catch {
                 print("Failed to set resolution to orientation \(orientation)")
             }


### PR DESCRIPTION
This upgrades to Hashinkit 1.5.2 - I have validated that this passes all tests and the example app still works as expected. Also confirmed switching of resolutions as some type changes were made on the Hashinkit side. I opted to not modify the interface types in this library to seamlessly support backwards compatibility. 

This PR is required to close https://github.com/apivideo/api.video-flutter-live-stream/issues/33